### PR TITLE
Update temporary slack join link with a permanent one

### DIFF
--- a/content/blog/2022/nextflow-is-moving-to-slack.md
+++ b/content/blog/2022/nextflow-is-moving-to-slack.md
@@ -27,7 +27,7 @@ As the Nextflow community continues to grow, we realize that we have reached the
 
 For these reasons, we felt that it is time to say goodbye to the beloved Nextflow Gitter channel and would like to welcome the community into the brand-new, official Nextflow workspace on Slack!    
 
-You can join today using <a target="_blank" href="https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg">this link</a>!
+You can join today using <a target="_blank" href="https://www.nextflow.io/slack-invite.html">this link</a>!
 
 Once you have joined, you will be added to a selection of generic channels. However, we have also set up various additional channels for discussion around specific Nextflow topics, and for infrastructure-related topics. Please feel free to join whichever channels are appropriate to you.
 

--- a/templates/menu.ftl
+++ b/templates/menu.ftl
@@ -44,7 +44,7 @@
                         <li><a href="http://nextflow-io.github.io/patterns/index.html">Implementation patterns</a></li>
                         <li><a href="https://github.com/nextflow-io/nextflow">GitHub repository</a></li>
                         <li><a href="https://github.com/nextflow-io/nextflow/discussions">Discussion forum</a></li>
-                        <li><a href="https://join.slack.com/t/nextflow/shared_invite/zt-11iwlxtw5-R6SNBpVksOJAx5sPOXNrZg">Slack community chat</a></li>
+                        <li><a href="https://www.nextflow.io/slack-invite.html">Slack community chat</a></li>
                         <li><a href="https://nf-co.re">nf-core Community pipelines</a></li>                       
                     </ul>
                 </li>


### PR DESCRIPTION
This change is related to the updates and discussions that occurred in https://github.com/nextflow-io/nextflow/pull/2917 and https://github.com/nextflow-io/website/pull/51.