### PR TITLE
Replace Google Group link by Slack Community Chat

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -361,10 +361,10 @@ status=published
 
         <div class="col-md-4 col-md-offset-1">
             <ul class="crp-blg-list">
-                <li><h3><a href="https://groups.google.com/forum/#!forum/nextflow" target="_blank">Confused? Ask the
+                <li><h3><a href="https://www.nextflow.io/slack-invite.html" target="_blank">Confused? Ask the
                     community</a></h3>
                     <div class="text-muted">
-                        A Nextflow discussion group is available on Google groups. Just click the above link.
+                        A Nextflow Community Chat is available on Slack. Just click the link above.
                     </div>
                 </li>
 


### PR DESCRIPTION
There was still a mention of Google Groups in the index page. It's now replaced by the Slack invite link.