### PR TITLE
Build the current docs on master too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *" # Daily, 1am
 
 jobs:
   build:

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -9,7 +9,7 @@ WEBSITE_DIR=$(pwd)
 # Make the empty target directories
 mkdir -p output/docs/latest/
 mkdir -p output/docs/edge/
-mkdir -p output/docs/dev/
+mkdir -p output/docs/master/
 
 # Fetch the Nextflow repo
 git clone https://github.com/nextflow-io/nextflow.git
@@ -37,8 +37,8 @@ pip install -r requirements.txt
 make clean html
 mv _build/html/* $WEBSITE_DIR/output/docs/latest/
 
-# Build current dev docs
+# Build current docs on master
 git checkout master
 pip install -r requirements.txt
 make clean html
-mv _build/html/* $WEBSITE_DIR/output/docs/dev/
+mv _build/html/* $WEBSITE_DIR/output/docs/master/

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -9,6 +9,7 @@ WEBSITE_DIR=$(pwd)
 # Make the empty target directories
 mkdir -p output/docs/latest/
 mkdir -p output/docs/edge/
+mkdir -p output/docs/dev/
 
 # Fetch the Nextflow repo
 git clone https://github.com/nextflow-io/nextflow.git
@@ -35,3 +36,9 @@ git checkout $STABLE_TAG
 pip install -r requirements.txt
 make clean html
 mv _build/html/* $WEBSITE_DIR/output/docs/latest/
+
+# Build current dev docs
+git checkout master
+pip install -r requirements.txt
+make clean html
+mv _build/html/* $WEBSITE_DIR/output/docs/dev/

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -56,8 +56,9 @@ const scrollClass = isHomepage ? ["scroll"] : [];
         <li class="dropdown show animated flipInX">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Community<b class="caret"></b></a>
           <ul class="dropdown-menu">
-            <li><a href="/docs/latest/index.html">Reference documentation</a></li>
-            <li><a href="/docs/edge/index.html">Edge release documentation</a></li>
+            <li><a href="/docs/latest/index.html">Documentation: Stable release</a></li>
+            <li><a href="/docs/edge/index.html">Documentation: Edge release</a></li>
+            <li><a href="/docs/dev/index.html">Documentation: Current dev</a></li>
             <li><a href="http://training.nextflow.io">Nextflow training</a></li>
             <li><a href="http://nextflow-io.github.io/patterns/index.html">Implementation patterns</a></li>
             <li><a href="/ambassadors.html">Nextflow Ambassadors</a></li>


### PR DESCRIPTION
Now that we're automating the build of the docs, I figure we can show the latest development docs off `master` too.

Updated the website build to trigger a nightly build to make sure that they're always up to date.