### PR TITLE
Improvements to the navbar

### DIFF
--- a/public/css/color-styles.css
+++ b/public/css/color-styles.css
@@ -182,6 +182,17 @@ i.style-toggle-btn {
   background-color: #0dc09d;
   border-color: #0dc09d;
 }
+.body-green .btn-outline-color {
+  background-color: transparent;
+  border-color: #0dc09d;
+  color: #0dc09d;
+}
+.body-green .btn-outline-color:hover,
+.body-green .btn-outline-color:focus,
+.body-green .btn-outline-color:active {
+  background-color: #0dc09d;
+  color: #fff;
+}
 .body-blue .btn-color {
   background-color: #3498db;
   border-color: #2980b9;

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -42,14 +42,24 @@ img {
 
 .navbar-brand {
   font-size: 26px;
+  padding: 15px;
+  margin-right: 20px;
 }
-.navbar-brand i {
-  font-size: 20px;
-  margin-right: 1px;
+.navbar-brand img {
+  height: 35px;
+  border: 0;
 }
 
 /* ===== Navbar ===== */
 
+.fa-sm {
+  font-size: 0.8em;
+  margin-left: 5px;
+}
+.navbar .fa-github {
+  font-size: 1.3333333333333333em;
+  line-height: 1em;
+}
 .navbar-inverse {
   background-color: #fff;
   border-color: #fff;
@@ -139,6 +149,11 @@ img {
   border-bottom-color: #000;
 }
 
+@media (min-width: 768px){
+  .navbar-collapse {
+    float: right;
+  }
+}
 @media (max-width: 767px) {
   .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
     border-color: #080808;
@@ -180,16 +195,17 @@ img {
 }
 @media (min-width: 768px) {
   .navbar-nav > li > a {
-    padding-top: 22.5px;
-    padding-bottom: 22.5px;
+    padding: 22.5px 10px;
+  }
+}
+@media (min-width: 1200px) {
+  .navbar-nav > li > a {
+    padding: 22.5px 20px;
   }
 }
 .navbar-form {
   margin-top: 15.5px;
   margin-bottom: 15.5px;
-}
-.navbar-brand {
-  padding: 22.5px 15px;
 }
 .navbar-btn {
   margin-top: 15.5px;

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -50,7 +50,7 @@ const isHomepage = currentPath === "/" || currentPath === "/index.html";
         </li>
 
         <li class="dropdown show animated flipInX">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Community<b class="caret"></b></a>
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown">Resources <b class="caret"></b></a>
           <ul class="dropdown-menu">
             <li><a href="/blog.html">Blog</a></li>
             <li><a href="/podcasts.html">Podcast</a></li>

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -29,6 +29,10 @@ const isHomepage = currentPath === "/" || currentPath === "/index.html";
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
+        <li class="show animated flipInX">
+          <a href="/docs/master/index.html">Documentation</a>
+        </li>
+
         <li class="dropdown show animated flipInX">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Examples <b class="caret"></b></a>
           <ul class="dropdown-menu">
@@ -39,10 +43,6 @@ const isHomepage = currentPath === "/" || currentPath === "/index.html";
             <li><a href="/example5.html">Machine Learning pipeline</a></li>
             <li><a href="https://github.com/CRG-CNAG/CalliNGS-NF/" target="_blank">Variant Calling pipeline</a></li>
           </ul>
-        </li>
-
-        <li class="show animated flipInX">
-          <a href="/docs/master/index.html">Documentation</a>
         </li>
 
         <li class="show animated flipInX">

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -1,7 +1,6 @@
 ---
 const currentPath = Astro.url.pathname;
 const isHomepage = currentPath === "/" || currentPath === "/index.html";
-const scrollClass = isHomepage ? ["scroll"] : [];
 ---
 
 <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
@@ -24,23 +23,12 @@ const scrollClass = isHomepage ? ["scroll"] : [];
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="/index.html" style="padding: 15px">
-        <img src="/img/nextflow.svg" height="35px" style="border: 0;" />
+      <a class="navbar-brand" href="/index.html">
+        <img src="/img/nextflow.svg" title="Nextflow" />
       </a>
     </div>
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
-        <li class="show animated flipInX">
-          <a href="/index.html#Features" class:list={scrollClass}>Features</a>
-        </li>
-        <li class="show animated flipInX">
-          <a href="/index.html#GetStarted" class:list={scrollClass}>Quick start</a>
-        </li>
-
-        <li class="show animated flipInX">
-          <a href="/blog/2023/learn-nextflow-in-2023.html">Learn Nextflow</a>
-        </li>
-
         <li class="dropdown show animated flipInX">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Examples <b class="caret"></b></a>
           <ul class="dropdown-menu">
@@ -53,33 +41,40 @@ const scrollClass = isHomepage ? ["scroll"] : [];
           </ul>
         </li>
 
+        <li class="show animated flipInX">
+          <a href="/docs/master/index.html">Documentation</a>
+        </li>
+
+        <li class="show animated flipInX">
+          <a href="http://training.nextflow.io">Training</a>
+        </li>
+
         <li class="dropdown show animated flipInX">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">Community<b class="caret"></b></a>
           <ul class="dropdown-menu">
-            <li><a href="/docs/latest/index.html">Documentation: Stable release</a></li>
-            <li><a href="/docs/edge/index.html">Documentation: Edge release</a></li>
-            <li><a href="/docs/master/index.html">Documentation: master branch</a></li>
-            <li><a href="http://training.nextflow.io">Nextflow training</a></li>
+            <li><a href="/blog.html">Blog</a></li>
+            <li><a href="/podcasts.html">Podcast</a></li>
+            <li><a href="/blog/2023/learn-nextflow-in-2023.html">Learn Nextflow</a></li>
             <li><a href="http://nextflow-io.github.io/patterns/index.html">Implementation patterns</a></li>
             <li><a href="/ambassadors.html">Nextflow Ambassadors</a></li>
-            <li><a href="https://github.com/nextflow-io/nextflow">GitHub repository</a></li>
-            <li><a href="https://community.seqera.io/c/nextflow/5">Community forum</a></li>
-            <li><a href="https://github.com/nextflow-io/nextflow/discussions">GitHub discussions</a></li>
             <li><a href="https://www.nextflow.io/slack-invite.html">Slack community chat</a></li>
-            <li><a href="https://nf-co.re">nf-core Community pipelines</a></li>
+            <li><a href="https://nf-co.re">nf-core pipelines</a></li>
+            <li><a href="/about-us.html">About Nextflow</a></li>
           </ul>
         </li>
 
         <li class="show animated flipInX">
-          <a href="/blog.html">Blog</a>
+          <a href="https://community.seqera.io/c/nextflow/5" target="_blank">
+            Forums
+            <i class="fa fa-sm fa-external-link" aria-hidden="true"></i>
+          </a>
         </li>
 
         <li class="show animated flipInX">
-          <a href="/podcasts.html">Podcast</a>
-        </li>
-
-        <li class="show animated flipInX">
-          <a href="/about-us.html">About</a>
+          <a href="https://github.com/nextflow-io/nextflow" title="GitHub Repository">
+            <i class="fa fa-github hidden-xs" aria-hidden="true"></i>
+            <span class="visible-xs">GitHub repository</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,8 +29,14 @@ import Layout from "@layouts/Layout.astro";
           </p>
 
           <p class="text-center">
-            <a href="#Features" class="btn btn-color btn-xxl scroll animated fadeInUp delay4">Documentation</a>
-            <a href="#Features" class="btn btn-outline-color btn-xxl scroll animated fadeInUp delay5">
+            <a href="/docs/master/index.html" class="btn btn-color btn-xxl scroll animated fadeInUp delay4"
+              >Documentation</a
+            >
+            <a
+              href="https://community.seqera.io/c/nextflow/5"
+              target="_blank"
+              class="btn btn-outline-color btn-xxl scroll animated fadeInUp delay5"
+            >
               Community forums
               <i class="fa fa-sm fa-external-link" aria-hidden="true"></i>
             </a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -28,8 +28,12 @@ import Layout from "@layouts/Layout.astro";
             on clouds and clusters.
           </p>
 
-          <p class="text-center animated fadeInUp delay4">
-            <a href="#Features" class="btn btn-color btn-xxl scroll">Find out more</a>
+          <p class="text-center">
+            <a href="#Features" class="btn btn-color btn-xxl scroll animated fadeInUp delay4">Documentation</a>
+            <a href="#Features" class="btn btn-outline-color btn-xxl scroll animated fadeInUp delay5">
+              Community forums
+              <i class="fa fa-sm fa-external-link" aria-hidden="true"></i>
+            </a>
           </p>
         </div>
       </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,13 +29,11 @@ import Layout from "@layouts/Layout.astro";
           </p>
 
           <p class="text-center">
-            <a href="/docs/master/index.html" class="btn btn-color btn-xxl scroll animated fadeInUp delay4"
-              >Documentation</a
-            >
+            <a href="/docs/master/index.html" class="btn btn-color btn-xxl animated fadeInUp delay4"> Documentation </a>
             <a
               href="https://community.seqera.io/c/nextflow/5"
               target="_blank"
-              class="btn btn-outline-color btn-xxl scroll animated fadeInUp delay5"
+              class="btn btn-outline-color btn-xxl animated fadeInUp delay5"
             >
               Community forums
               <i class="fa fa-sm fa-external-link" aria-hidden="true"></i>


### PR DESCRIPTION
Some tweaks to the navbar. Main changes:

* Move documentation out of the "Community" dropdown, so that it's easier to find
* Collapse 3x docs links to one. This goes to the nightly `master` build - once there the sidebar has a dropdown to jump to the `latest` and `edge` versions of the docs.
* Remove 2x navbar links which go to different parts of the homepage