### PR TITLE
Docs: master->latest, latest->stable

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -9,7 +9,7 @@ WEBSITE_DIR=$(pwd)
 # Make the empty target directories
 mkdir -p output/docs/latest/
 mkdir -p output/docs/edge/
-mkdir -p output/docs/master/
+mkdir -p output/docs/stable/
 
 # Fetch the Nextflow repo
 git clone https://github.com/nextflow-io/nextflow.git
@@ -35,10 +35,10 @@ mv _build/html/* $WEBSITE_DIR/output/docs/edge/
 git checkout $STABLE_TAG
 pip install -r requirements.txt
 make clean html
-mv _build/html/* $WEBSITE_DIR/output/docs/latest/
+mv _build/html/* $WEBSITE_DIR/output/docs/stable/
 
 # Build current docs on master
 git checkout master
 pip install -r requirements.txt
 make clean html
-mv _build/html/* $WEBSITE_DIR/output/docs/master/
+mv _build/html/* $WEBSITE_DIR/output/docs/latest/

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -26,18 +26,21 @@ if [ ${#STABLE_TAG} -le 4 ]; then echo "Version string too short" ; exit 1; fi
 if [ ${#EDGE_TAG} -le 4 ]; then echo "Version string too short" ; exit 1; fi
 
 # Build edge docs
+echo "===============  Building edge docs: $EDGE_TAG  ==============="
 git checkout $EDGE_TAG
 pip install -r requirements.txt
 make clean html
 mv _build/html/* $WEBSITE_DIR/output/docs/edge/
 
 # Build stable docs
+echo "===============  Building stable docs: $STABLE_TAG  ==============="
 git checkout $STABLE_TAG
 pip install -r requirements.txt
 make clean html
 mv _build/html/* $WEBSITE_DIR/output/docs/stable/
 
 # Build current docs on master
+echo "===============  Building latest docs: master  ==============="
 git checkout master
 pip install -r requirements.txt
 make clean html

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -30,7 +30,7 @@ const isHomepage = currentPath === "/" || currentPath === "/index.html";
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         <li class="show animated flipInX">
-          <a href="/docs/master/index.html">Documentation</a>
+          <a href="/docs/latest/index.html">Documentation</a>
         </li>
 
         <li class="dropdown show animated flipInX">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,7 +29,7 @@ import Layout from "@layouts/Layout.astro";
           </p>
 
           <p class="text-center">
-            <a href="/docs/master/index.html" class="btn btn-color btn-xxl animated fadeInUp delay4"> Documentation </a>
+            <a href="/docs/latest/index.html" class="btn btn-color btn-xxl animated fadeInUp delay4"> Documentation </a>
             <a
               href="https://community.seqera.io/c/nextflow/5"
               target="_blank"


### PR DESCRIPTION
Implementation of https://github.com/nextflow-io/nextflow/issues/4877#issuecomment-2034947483

> [ @bentsherman ]
> Why don't we just change `/docs/latest/` to point to the master branch build?
> 
> * `/docs/latest` -> master branch
> * `/docs/edge` -> edge release (optional)
> * `/docs/stable` -> stable release (optional)

> [!CAUTION]
> The `/docs/master` URL will cease to exist.
> [docs.nextflow.io](https://docs.nextflow.io) must be reverted back to the previous behaviour of pointing to `/docs/latest` _before_ merging this PR.