### PR TITLE
Share image: check that the file exists during build

### DIFF
--- a/src/content/blog/2022/caching-behavior-analysis.md
+++ b/src/content/blog/2022/caching-behavior-analysis.md
@@ -3,7 +3,6 @@ title: Analyzing caching behavior of pipelines
 date: 2022-11-10
 type: post
 description: A guide to analysis of dump-hashes for troubleshooting caching behavior.
-image: /img/rnaseq-nf.fastqc.modified.png
 tags: nextflow,cache
 author: Abhinav Sharma
 icon: abhinav.jpg

--- a/src/content/blog/2023/nextflow-with-gbatch.md
+++ b/src/content/blog/2023/nextflow-with-gbatch.md
@@ -3,7 +3,6 @@ title: Get started with Nextflow on Google Cloud Batch
 date: 2023-02-01
 type: post
 description: We've talked about deploying Nextflow pipelines with Google Cloud Batch in the past. Join us again for an extended and updated version
-image: /img/gbatch_extended.jpg
 tags: nextflow,google,cloud
 author: Marcel Ribeiro-Dantas
 icon: marcel.jpg

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,9 @@
 import Menu from "@components/Menu.astro";
 import Footer from "@components/Footer.astro";
 
+import { existsSync } from "fs";
+import path from "path";
+
 interface Props {
   title: string;
   description?: string;
@@ -13,7 +16,13 @@ const { title, description, image } = Astro.props;
 const page_title = title + " | Nextflow";
 
 const netlifyPrimeURL = import.meta.env.DEPLOY_PRIME_URL;
-const share_image = (netlifyPrimeURL || Astro.url.origin) + (image || "/img/share.png");
+const image_path = image || "/img/share.png";
+const share_image = (netlifyPrimeURL || Astro.url.origin) + image_path;
+
+// Check that the share card image exists
+if (!existsSync(path.join(path.resolve("./public"), image_path))) {
+  throw new Error(`The file at public${image_path} does not exist.`);
+}
 ---
 
 <!doctype html>


### PR DESCRIPTION
Should now throw a build error if the share image file doesn't exist.

Hopefully will catch things like jpg / png mistakes 👀 

Adds on top of the existing check for the filename beginning with `/img/`