### PR TITLE
.trim() removed to keep new lines between collected versions

### DIFF
--- a/src/content/blog/2024/nextflow-24.04-highlights.md
+++ b/src/content/blog/2024/nextflow-24.04-highlights.md
@@ -156,10 +156,10 @@ workflow {
   Channel.topic('versions') // [!code ++]
     | unique()
     | map { process, name, version ->
-      """
+      """\
       ${process.tokenize(':').last()}:
         ${name}: ${version}
-      """.stripIndent().trim()
+      """.stripIndent()
     }
     | collectFile(name: 'collated_versions.yml')
     | CUSTOM_DUMPSOFTWAREVERSIONS


### PR DESCRIPTION
On the page with 20.04 release highlights, in the Collecting version subsection, within an example code snippet, .trim() was removed to keep newline between recorded versions. 

old:
```
workflow {
  Channel.topic('versions') 
    | unique()
    | map { process, name, version ->
      """
      ${process.tokenize(':').last()}:
        ${name}: ${version}
      """.stripIndent().trim()
    }
    | collectFile(name: 'collated_versions.yml')
    | CUSTOM_DUMPSOFTWAREVERSIONS
}
```

new:
```
workflow {
  Channel.topic('versions') 
    | unique()
    | map { process, name, version ->
      """\
      ${process.tokenize(':').last()}:
        ${name}: ${version}
      """.stripIndent()
    }
    | collectFile(name: 'collated_versions.yml')
    | CUSTOM_DUMPSOFTWAREVERSIONS
}
```


Output file example after `.trim()` is removed:
```
PREPROCESSING:
  cutadapt: 4.7
PREPROCESSING:
  ribodetector: 0.3.1
GET_SAMPLE_INFO:
  scd: 1.4.22
```