### PR TITLE
HTML vscode redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,11 +4,3 @@
 
 [build.environment]
     NODE_VERSION = "20.11.0"
-
-[[redirects]]
-  from = "/vscode"
-  to = "https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow"
-
-[[redirects]]
-  from = "/openvsx"
-  to = "https://open-vsx.org/extension/nextflow/nextflow"

--- a/src/pages/vscode.astro
+++ b/src/pages/vscode.astro
@@ -1,0 +1,11 @@
+---
+// VSCode marketplace redirect
+---
+
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://marketplace.visualstudio.com/items?itemName=nextflow.nextflow" />
+  </head>
+
+
+</html>


### PR DESCRIPTION
Update for https://github.com/nextflow-io/website/pull/317

Forgot that the production site isn't hosted on Netlify, so Netlify redirects won't work.

HTML redirects is the best that we can do I think :/ 