### PR TITLE
Add Javier Carpinteyro Ponce as Nextflow Ambassador

### DIFF
--- a/src/pages/our_ambassadors.astro
+++ b/src/pages/our_ambassadors.astro
@@ -618,6 +618,20 @@ import AmbassadorCard from "@components/AmbassadorCard/index.tsx";
 
       <AmbassadorCard
         client:load
+        name="Javier Carpinteyro Ponce"
+        img="javi.jpg"
+        country="mx"
+        github="javibio-git"
+        linkedin="javier-carpinteyro-ponce"
+      >
+        Javier (Javi) is a bioinformatics research associate at <a href="https://carnegiescience.edu" target="_blank">Carnegie Science</a>.
+        He currently provides bioinformatics support to bench-based researchers helping them with their data analysis needs. He is also
+        interested in developing reproducible and scalable workflows for population genomics.
+
+      </AmbassadorCard>
+
+      <AmbassadorCard
+        client:load
         name="Jeferyd Yepes"
         img="jeferyd.jpg"
         country="ch"


### PR DESCRIPTION
- Adds Ambassador card to `website\src\pages\our_ambassadors.astro`
- Adds javi.jpg to `website\public\img\`