### PR TITLE
Forcing sphinx build

### DIFF
--- a/build_docs.sh
+++ b/build_docs.sh
@@ -37,19 +37,19 @@ if [ ${#EDGE_TAG} -le 4 ]; then echo "Version string too short" ; exit 1; fi
 echo "===============  Building edge docs: $EDGE_TAG  ==============="
 git checkout $EDGE_TAG
 pip install -r requirements.txt
-make clean html
+make clean html SPHINXBUILD="python -m sphinx"
 mv _build/html/* $WEBSITE_DIR/output/docs/edge/
 
 # Build stable docs
 echo "===============  Building stable docs: $STABLE_TAG  ==============="
 git checkout $STABLE_TAG
 pip install -r requirements.txt
-make clean html
+make clean html SPHINXBUILD="python -m sphinx"
 mv _build/html/* $WEBSITE_DIR/output/docs/stable/
 
 # Build current docs on master
 echo "===============  Building latest docs: master  ==============="
 git checkout master
 pip install -r requirements.txt
-make clean html
+make clean html SPHINXBUILD="python -m sphinx"
 mv _build/html/* $WEBSITE_DIR/output/docs/latest/


### PR DESCRIPTION
Hi @ewels and @mribeirodantas 

Could you help me to review this?
## Problem

After Netlify updated to the Ubuntu Noble build image (the previous one reached end-of-life in January 2026), the documentation build on Netlify started failing with "sphinx-build: No such file or directory" errors.
<img width="844" height="309" alt="image" src="https://github.com/user-attachments/assets/1099ae06-c025-48f6-9630-b7d4e6afa468" />

The Python packages were installing correctly, but the `sphinx-build` executable wasn't accessible when the Makefile tried to run it.

## Vibe coding Solution

Instead of modifying the Makefile in the Nextflow repo (which gets cloned fresh during each build), I'm now passing `SPHINXBUILD="python -m sphinx"` directly to the make commands in `build_docs.sh`.

This overrides the Makefile's default and uses Python's module execution, which works regardless of PATH configuration.
