### PR TITLE
Fixing ambassadors card

### DIFF
--- a/src/components/AmbassadorCard/ambassador.css
+++ b/src/components/AmbassadorCard/ambassador.css
@@ -1,8 +1,8 @@
 .ambassador-bio-content a {
-  color: var(--color-nextflow-800);
+  color: var(--color-nextflow-900);
   position: relative;
   text-decoration: none;
-  background-image: linear-gradient(var(--color-nextflow-600), var(--color-nextflow-600));
+  background-image: linear-gradient(var(--color-nextflow-900), var(--color-nextflow-900));
   background-position: 0% 100%;
   background-repeat: no-repeat;
   background-size: 0% 1px;

--- a/src/components/AmbassadorCard/index.tsx
+++ b/src/components/AmbassadorCard/index.tsx
@@ -76,14 +76,14 @@ const AmbassadorCard: React.FC<AmbassadorCardProps> = ({
       </div>
 
       <div className="ambassador-info flex flex-col flex-1 bg-white">
-        <div className="flex flex-col justify-between h-full">
-          <div className="p-4">
-            <h2 className="text-lg font-semibold text-brand-1000 my-0">{name}</h2>
+        <div className="flex flex-col h-full">
+          <div className="p-4 pb-2 flex-1 flex items-start">
+            <h2 className="text-lg font-semibold text-brand-1000 my-0 leading-tight">{name}</h2>
           </div>
-          <div className="flex flex-col px-4">
+          <div className="flex flex-col px-4 pb-3">
             <div className="flex items-center mb-0 min-h-[24px]">{children && <BioToggleButton />}</div>
           </div>
-          <div className="p-4 flex gap-4 items-center social-container bg-white">
+          <div className="p-4 pt-2 flex gap-4 items-center social-container bg-white">
           {github && (
             <a
               href={`https://github.com/${github}`}


### PR DESCRIPTION
Hi!
Fixed some things on the ambassador card. 

**1. The underline in the links was not working well. Just underlanding the last part.  Also I change the color as before was too light and didn't pass the color contrast ratio.** 

**Before:** 
<img width="200" height="90" alt="Captura de pantalla 2026-01-16 a las 15 52 16" src="https://github.com/user-attachments/assets/a580fdb4-8ff7-42b2-a1c4-c4af586a28dd" />

**Now:**
<img width="198" height="68" alt="Captura de pantalla 2026-01-16 a las 15 54 27" src="https://github.com/user-attachments/assets/518b7b2c-7619-4568-a212-b432f4f65a92" />


**2. The bio has a strange structure, sometimes appearing under social. With this fixe I also aligned content structure.** 

**Before:**

https://github.com/user-attachments/assets/f4061416-b6d7-4a5f-8ad0-c35e604dddde

<img width="763" height="208" alt="Captura de pantalla 2026-01-16 a las 15 57 30" src="https://github.com/user-attachments/assets/77af70cc-1071-4cc7-833a-af9fae2d3030" />

**After** 

https://github.com/user-attachments/assets/95d20cee-93d7-457d-baca-e9b37c34e066

<img width="1299" height="233" alt="Captura de pantalla 2026-01-16 a las 15 58 59" src="https://github.com/user-attachments/assets/5690d20c-57d7-4519-967c-589fb3219b07" />


**3. The scrolling bio when there is long text**

**Before**:
<img width="237" height="392" alt="Captura de pantalla 2026-01-16 a las 16 03 07" src="https://github.com/user-attachments/assets/0ef1f589-33ce-496f-9323-681f32009603" />

**After:** 

https://github.com/user-attachments/assets/f7098a9f-b7b7-4bf6-995d-bf0e45b0c21b


