### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **nextflow.io** website, a static site built with [Astro](https://astro.build). Node 20+ is used (CI uses 20, the devcontainer uses 22). Dependencies are installed by the startup update script (`npm install`), so you normally do not need to install anything manually.
+
+### Running the dev server
+
+- Start it with `npm run dev` (alias for `astro dev`). It serves at `http://localhost:4321/` and live-reloads on file changes.
+- Pages live in `src/pages/` (`.astro`/`.md`) and content collections in `src/content/` (blog, podcast). Each file maps to a route by filename.
+
+### Non-obvious gotchas
+
+- **No local blog/docs.** The dev server does NOT build the Nextflow documentation. The site's "Blog" navigation links point to the external `seqera.io` blog, so there is no local `/blog/` route (it 404s) — this is expected. Test rendering with real local pages instead, e.g. `/`, `/our_ambassadors`, `/examples`, `/about-us`.
+- **Full build is heavy.** `npm run build` runs `astro check && astro build && bash build_docs.sh`. `build_docs.sh` clones the entire `nextflow-io/nextflow` repo and builds the Sphinx docs (requires network, Python, `jq`, and `pip` deps). For quick local verification of the website itself, run `npx astro build` (skips docs) and/or `npx astro check` (type check) instead. Build output goes to `output/` (gitignored).
+
+### Lint / typecheck
+
+- Formatting is enforced by Prettier via pre-commit (see `.pre-commit-config.yaml`). Check with `npx prettier --check "**/*.{astro,mdx,md,yml,yaml,ts,js,mjs}"`.
+- Type checking: `npx astro check`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the nextflow.io Astro website, and adds an `AGENTS.md` with durable, non-obvious notes for future Cloud agents.

### What was verified
- `npm install` — dependencies install cleanly (Node 22).
- `npx prettier --check` — formatting passes.
- `npx astro check` — type check passes (0 errors).
- `npx astro build` — static site builds (50 pages).
- `npm run dev` — dev server runs at `http://localhost:4321/` and renders pages.

### Hello-world demonstration
Navigated the running dev server across three local pages (homepage, `/our_ambassadors`, `/examples`); all rendered correctly.

[nextflow_dev_site_navigation.mp4](https://cursor.com/agents/bc-62d793be-c18b-4442-8301-895df34e0d08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextflow_dev_site_navigation.mp4)

[Homepage](https://cursor.com/agents/bc-62d793be-c18b-4442-8301-895df34e0d08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Ambassadors page](https://cursor.com/agents/bc-62d793be-c18b-4442-8301-895df34e0d08/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fambassadors_page.webp)

### Notes captured in AGENTS.md
- The dev server does not build docs; "Blog" links go to external `seqera.io` (no local `/blog/`).
- The full `npm run build` clones the Nextflow repo and builds Sphinx docs (heavy); use `npx astro build` for quick local verification.

The startup update script is `npm install`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62d793be-c18b-4442-8301-895df34e0d08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62d793be-c18b-4442-8301-895df34e0d08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

